### PR TITLE
fix: select zone for region tests 

### DIFF
--- a/examples/region/useast1/main.tf
+++ b/examples/region/useast1/main.tf
@@ -12,12 +12,11 @@ locals {
   category       = "region"
   example        = "useast1"
   email          = "terraform-ci@suse.com"
-  name           = "tf-aws-server-${local.category}-${local.example}-${local.identifier}"
-  username       = "tf-ci-${local.identifier}"
+  name           = "tf-${local.category}-${local.example}-${local.identifier}"
+  username       = "tf-${local.identifier}"
   image          = "sles-15"
-  public_ssh_key = var.key      # I don't normally recommend this, but it allows tests to supply their own key
-  key_name       = var.key_name # A lot of troubleshooting during critical times can be saved by hard coding variables in root modules
-  # root modules should be secured properly (including the state), and should represent your running infrastructure
+  public_ssh_key = var.key
+  key_name       = var.key_name
 }
 
 module "access" {
@@ -30,6 +29,7 @@ module "access" {
   subnet_cidr         = "10.0.255.224/28" # gives 14 usable addresses from .225 to .238, but AWS reserves .225 to .227 and .238, leaving .227 to .237
   security_group_name = local.name
   security_group_type = "specific"
+  availability_zone   = "us-east-1a" # specific region because there is a random chance us-east-1e will be chosen which doesn't allow this server type
   skip_ssh            = true
 }
 

--- a/examples/region/useast2/main.tf
+++ b/examples/region/useast2/main.tf
@@ -12,8 +12,8 @@ locals {
   category       = "region"
   example        = "useast2"
   email          = "terraform-ci@suse.com"
-  name           = "tf-aws-server-${local.category}-${local.example}-${local.identifier}"
-  username       = "tf-ci-${local.identifier}"
+  name           = "tf-${local.category}-${local.example}-${local.identifier}"
+  username       = "tf-${local.identifier}"
   image          = "sles-15"
   public_ssh_key = var.key
   key_name       = var.key_name
@@ -29,6 +29,7 @@ module "access" {
   subnet_cidr         = "10.0.255.224/28" # gives 14 usable addresses from .225 to .238, but AWS reserves .225 to .227 and .238, leaving .227 to .237
   security_group_name = local.name
   security_group_type = "specific"
+  availability_zone   = "us-east-2a" # specifying this zone because there is a small chance a zone that doesn't offer this server type is chosen
   skip_ssh            = true
 }
 

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -46,13 +46,10 @@ func TestNoAccess(t *testing.T) {
 	region := "us-west-1"
 	owner := "terraform-ci@suse.com"
 	terraformOptions, keyPair := setup(t, category, directory, region, owner)
-
-	sshAgent := ssh.SshAgentWithKeyPair(t, keyPair.KeyPair)
-	defer sshAgent.Stop()
-	terraformOptions.SshAgent = sshAgent
-
 	defer teardown(t, category, directory, keyPair)
 	defer terraform.Destroy(t, terraformOptions)
+	delete(terraformOptions.Vars, "key")
+	delete(terraformOptions.Vars, "key_name")
 	terraform.InitAndApply(t, terraformOptions)
 }
 func TestPrivateIp(t *testing.T) {
@@ -62,12 +59,9 @@ func TestPrivateIp(t *testing.T) {
 	region := "us-west-1"
 	owner := "terraform-ci@suse.com"
 	terraformOptions, keyPair := setup(t, category, directory, region, owner)
-
-	sshAgent := ssh.SshAgentWithKeyPair(t, keyPair.KeyPair)
-	defer sshAgent.Stop()
-	terraformOptions.SshAgent = sshAgent
-
 	defer teardown(t, category, directory, keyPair)
 	defer terraform.Destroy(t, terraformOptions)
+	delete(terraformOptions.Vars, "key")
+	delete(terraformOptions.Vars, "key_name")
 	terraform.InitAndApply(t, terraformOptions)
 }


### PR DESCRIPTION
and remove key and key_name when not necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified naming conventions for resources in the `useast1` and `useast2` regions.
	- Improved security practices by adjusting the configuration for resource creation.
	- Specified `availability_zone` to ensure selection of a specific region for server deployment.
- **Tests**
	- Removed SSH agent setup and configuration from basic tests to streamline testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->