### PR TITLE
fix: remove version constraints

### DIFF
--- a/examples/basic/basic/versions.tf
+++ b/examples/basic/basic/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/basic/directnetworkdomain/versions.tf
+++ b/examples/basic/directnetworkdomain/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/basic/directnetworkonly/versions.tf
+++ b/examples/basic/directnetworkonly/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/basic/directssheip/versions.tf
+++ b/examples/basic/directssheip/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/basic/directsshsubnet/versions.tf
+++ b/examples/basic/directsshsubnet/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/basic/dualstack/versions.tf
+++ b/examples/basic/dualstack/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/basic/indirectdomain/versions.tf
+++ b/examples/basic/indirectdomain/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/basic/indirectonly/versions.tf
+++ b/examples/basic/indirectonly/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/basic/privateip/versions.tf
+++ b/examples/basic/privateip/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/imagetype/basic/versions.tf
+++ b/examples/imagetype/basic/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/imagetype/custom/versions.tf
+++ b/examples/imagetype/custom/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/os/all/versions.tf
+++ b/examples/os/all/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/region/useast1/versions.tf
+++ b/examples/region/useast1/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/region/useast2/versions.tf
+++ b/examples/region/useast2/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/region/uswest1/versions.tf
+++ b/examples/region/uswest1/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/region/uswest2/versions.tf
+++ b/examples/region/uswest2/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/select/all/versions.tf
+++ b/examples/select/all/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/select/image/versions.tf
+++ b/examples/select/image/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/select/server/versions.tf
+++ b/examples/select/server/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/size/large/versions.tf
+++ b/examples/size/large/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/size/medium/versions.tf
+++ b/examples/size/medium/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/size/small/versions.tf
+++ b/examples/size/small/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/size/xl/versions.tf
+++ b/examples/size/xl/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/size/xxl/versions.tf
+++ b/examples/size/xxl/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/modules/direct_access/versions.tf
+++ b/modules/direct_access/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/image/versions.tf
+++ b/modules/image/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/modules/indirect_access/versions.tf
+++ b/modules/indirect_access/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/server/versions.tf
+++ b/modules/server/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
Don't constrain the Terraform version to only use the non BUSL versions.
Users are responsible for how they use our module and whether they are in compliance with their use of Terraform.