### PR TITLE
fix: initial admin group missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ examples/*/50-*
 *.DS_*
 test/data/*
 *.test
+.claude
+.claude/*

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776225522,
-        "narHash": "sha256-W2npO5nesUm68vECpC3Dl/IOzamvcGAu9uV38hou2yg=",
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "975dad1a84d727dce241bb41b27191948fa5a956",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
         "type": "github"
       },
       "original": {

--- a/modules/direct_access/initial.sh
+++ b/modules/direct_access/initial.sh
@@ -34,6 +34,18 @@ if [ "${IGNORE_CLOUDINIT}" -eq 1 ]; then
   echo "cloud-init not found or ignored, attempting other tools...";
   # check for user, if it doesn't exist generate it
   if [ "$(awk -F: '{ print $1 }' /etc/passwd | grep "${USER}")" = "" ]; then
+    # check if admin group exists, create it if missing
+    if [ "$(getent group "${ADMIN_GROUP}")" = "" ]; then
+      echo "Admin group '${ADMIN_GROUP}' not found, creating it...";
+      if [ "$(command -v groupadd)" != "" ]; then
+        groupadd "${ADMIN_GROUP}"
+      elif [ "$(command -v addgroup)" != "" ]; then
+        addgroup "${ADMIN_GROUP}"
+      else
+        echo "No supported group creation tool found";
+        EXIT=1
+      fi
+    fi
     if [ "$(command -v addgroup)" != "" ]; then
         addgroup "${USER}" # generate a group for the user
         adduser  --ingroup "${USER}" --shell "/bin/sh" --disabled-password --gecos "${USER}" "${USER}"

--- a/test/tests/os/os_test.go
+++ b/test/tests/os/os_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -73,6 +74,32 @@ func TestOs(t *testing.T) {
 			assert.True(t, ok, fmt.Sprintf("Wrong data type for 'image', expected map[string], got %T", out["image"]))
 			assert.NotEmpty(t, outputServer["public_ip"], "The 'server.public_ip' is empty")
 			assert.NotEmpty(t, outputImage["id"], "The 'image.id' is empty")
+
+			// Validate SSH connection and user setup
+			publicIP, ok := outputServer["public_ip"].(string)
+			assert.True(t, ok, "public_ip is not a string")
+			identifier := terraformOptions.Vars["identifier"].(string)
+			username := strings.ToLower(fmt.Sprintf("tf-%s", identifier))
+			if len(username) > 32 {
+				username = username[:32]
+			}
+
+			host := ssh.Host{
+				Hostname:    publicIP,
+				SshUserName: username,
+				SshKeyPair:  keyPair.KeyPair,
+			}
+
+			// Test SSH connection
+			t.Logf("Testing SSH connection to %s@%s", username, publicIP)
+			result := ssh.CheckSshCommand(t, host, "whoami")
+			assert.Contains(t, result, username, "SSH connection failed or returned unexpected user")
+
+			// Test sudo access
+			t.Logf("Testing sudo access for %s", username)
+			sudoResult := ssh.CheckSshCommand(t, host, "sudo whoami")
+			assert.Contains(t, sudoResult, "root", "Sudo access failed")
+
 			util.Teardown(t, category, directory, keyPair, sshAgent, uniqueID, terraformOptions)
 		})
 	}


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
Found that there is an instance where the admin group may be missing on some OS builds. This adds the admin group if it is missing and adds tests to validate all OS images can be accessed after launch.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
adds validation
<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
