### PR TITLE
fix: update owner and mode to home runner path

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -21,10 +21,8 @@ jobs:
       - name: Fix Runner Permissions
         shell: bash
         run: |
-          sudo chown -R "$(whoami)" "$RUNNER_TEMP"
-          sudo chown -R "$(whoami)" "$(dirname "$GITHUB_EVENT_PATH")"
-          sudo chown -R "$(whoami)" "$GITHUB_WORKSPACE"
-          sudo chown -R "$(whoami)" "$HOME"
+          sudo chown -R "$(whoami)" /home/runner
+          sudo chmod -R 0770 /home/runner
 
       - name: Checkout
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,10 +28,8 @@ jobs:
       - name: Fix Runner Permissions
         shell: bash
         run: |
-          sudo chown -R "$(whoami)" "$RUNNER_TEMP"
-          sudo chown -R "$(whoami)" "$(dirname "$GITHUB_EVENT_PATH")"
-          sudo chown -R "$(whoami)" "$GITHUB_WORKSPACE"
-          sudo chown -R "$(whoami)" "$HOME"
+          sudo chown -R "$(whoami)" /home/runner
+          sudo chmod -R 0770 /home/runner
 
       - name: 'Release Please'
         # https://github.com/googleapis/release-please-action/releases


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
Workflows are failing due to file permissions, updating the home runner path to be owned by the user and able to be executed by owner.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
actionlint
<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? -->
<!--- If so, change the following line with an explanation. --->
Not a breaking change.
