### PR TITLE
fix: correct permissions in the container

### DIFF
--- a/.github/workflows/scripts/nix-run.sh
+++ b/.github/workflows/scripts/nix-run.sh
@@ -23,6 +23,13 @@ trap 'rm -f .nix-script.sh' EXIT
 # Ensure the suse user can read/write the script and current directory
 chown -R suse:suse . || true
 
+# Ensure parent directories are traversable by the suse user
+p="$PWD"
+while [ "$p" != "/" ] && [ -n "$p" ]; do
+  chmod a+rx "$p" 2>/dev/null || true
+  p="$(dirname "$p")"
+done
+
 sudo -E -u suse /home/suse/.nix-profile/bin/nix develop \
   --ignore-environment \
   --extra-experimental-features nix-command \


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
Some added permissions are required to run the nix-run script in the contianer.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? -->
<!--- If so, change the following line with an explanation. --->
Not a breaking change.
