### PR TITLE
fix: resolve broken dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,18 @@
 version: 2
 updates:
-  - package-ecosystem: "docker"
-    directory: "/.github/workflows"
+  # Check for updates to GitHub Actions every week
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
+      day: "sunday" # this way it is ready for review on Monday
+    commit-message:
+      prefix: "fix"
+  # Check for updates to terraform providers every week
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday" # this way it is ready for review on Monday
+    commit-message:
+      prefix: "fix"


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
Dependabot is failing https://github.com/rancher/terraform-aws-server/actions/runs/27931860083
This removes the docker file ecosystem since we don't have any docker files.
We originally wanted dependabot to update the container image in the workflow jobs, but it doesn't seem like dependabot will do this.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? -->
<!--- If so, change the following line with an explanation. --->
Not a breaking change.
